### PR TITLE
[fix] 컨테이너가 스크롤 범위를 벗어났을 때 Toolbar에 붙지 않도록 스타일 수정 #3

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "pr-tree-viewer",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "manifest_version": 2,
   "description": "PR의 변경된 파일들을 트리 구조로 볼 수 있도록 도와주는 크롬 익스텐션",
   "permissions": [

--- a/src/index.css
+++ b/src/index.css
@@ -6,6 +6,10 @@
   margin-left: 375px;
 }
 
+#files_bucket > .pr-toolbar.is-stuck #pr-tree-viewer-root {
+  top: 70px;
+}
+
 /* ----- PR-Tree-Viewer CSS ----- */
 #pr-tree-viewer-root {
   position: absolute;


### PR DESCRIPTION
### 연관 이슈
[https://github.com/Pewww/pr-tree-viewer/issues/3](https://github.com/Pewww/pr-tree-viewer/issues/3)

### 작업 내용
제목과 동일합니다.
현재 컨테이너(익스텐션)가 pr-toolbar에 종속되어 있는데, 해당 엘리먼트가 is-stuck 클래스를 가지게 될 때 컨테이너의 top을 70px로 설정하여 해결하였습니다.