### PR TITLE
[fix] 박스(컨테이너)가 레이아웃 영역을 넘지 않도록 스타일 수정 #11

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "pr-tree-viewer",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "manifest_version": 2,
   "description": "PR의 변경된 파일들을 트리 구조로 볼 수 있도록 도와주는 크롬 익스텐션",
   "permissions": [

--- a/src/index.css
+++ b/src/index.css
@@ -19,7 +19,7 @@
   width: 370px;
   min-width: 370px;
   max-width: 640px;
-  height: 650px;
+  height: auto;
   min-height: 200px;
   max-height: calc(100vh - 190px);
   background-color: transparent;


### PR DESCRIPTION
### 연관 이슈
[https://github.com/Pewww/pr-tree-viewer/issues/11](https://github.com/Pewww/pr-tree-viewer/issues/11)

### 작업 내용
파일의 변경점이 그렇게 많지 않아 기본적으로 컨테이너에 설정되어있는 height 보다 설정(높이) 값이 낮을 시 레이아웃 영역을 벗어나는 문제가 발생하였습니다.
컨테이너의 height를 고정값(`650px`)이 아닌 `auto`로 설정함으로써 해결하였습니다.