### PR TITLE
ChangedFiles에서 모든 변경된 파일을 감지하지 못하고 에러를 내는 것을 수정합니다.

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,9 +7,9 @@
   "license": "MIT",
   "scripts": {
     "build": "webpack --mode production",
-    "format": "prettier './src/**/*.ts' --write",
-    "lint": "eslint './src/**/*.ts'",
-    "lint:fix": "eslint --fix './src/**/*.ts'"
+    "format": "prettier ./src/**/*.ts --write",
+    "lint": "eslint ./src/**/*.ts",
+    "lint:fix": "eslint --fix ./src/**/*.ts"
   },
   "dependencies": {
     "copy-webpack-plugin": "^7.0.0",

--- a/src/models/ChangedFiles.ts
+++ b/src/models/ChangedFiles.ts
@@ -41,7 +41,7 @@ export default class ChangedFiles {
 
   private getFileSrcs() {
     const fileSrcTags = Array.from(
-      document.querySelectorAll(`.${this.rootClassName} > a`)
+      document.querySelectorAll(`.${this.rootClassName} > .diffstat + a`)
     );
 
     return fileSrcTags.map(({ title }: HTMLElement) =>


### PR DESCRIPTION
안녕하세요. pr-tree-viewer 사용 중에 모든 변경된 파일을 감지하지 못하는 문제를 발견하여 해결하는 PR을 올립니다.

Github에서는 [Unchanged files with check annotations](https://developer.github.com/changes/2019-09-06-more-check-annotations-shown-in-files-changed-tab/)라는 Beta feature를 제공하고 있는데, Github Actions를 통해 lint와 같은 작업을 할 경우 뜨는 warning / error를 감지하여 해당 코드를 알려주는 기능입니다. 
해당 기능에서 코드 파일 이름을 보여주는 형식도 `.file-info > a`이기 때문에 해당 query로 얻고 있는 fileSrcs가 오염되고 있고, 이렇게 오염된 fileSrcs를 이용해 forEach문을 돌린다던가, createNestedLayer를 하면서 실제로 diff가 아닌 annotation file들이 에러를 발생시켜 중간에 동작이 멈추곤 합니다. 따라서 심하면 절반 정도의 file changes가 tree-viewer에서 보이지 않는 현상이 발생했습니다.

따라서 fileSrcs에 의존적인 부분들을 diffStatTags or diffStat를 의존하도록 변경하여, 정상적이지 않은 src를 참조하지 않도록 수정하였습니다.